### PR TITLE
Fixed broken padding and errno

### DIFF
--- a/src/spiffs.h
+++ b/src/spiffs.h
@@ -180,7 +180,7 @@ typedef struct {
   u32_t fd_count;
 
   // last error
-  s32_t errno;
+  s32_t errnum;
 
   // current number of free blocks
   u32_t free_blocks;

--- a/src/spiffs_hydrogen.c
+++ b/src/spiffs_hydrogen.c
@@ -101,7 +101,7 @@ void ICACHE_FLASH_ATTR SPIFFS_unmount(spiffs *fs) {
 }
 
 s32_t ICACHE_FLASH_ATTR SPIFFS_errno(spiffs *fs) {
-  return fs->errno;
+  return fs->errnum;
 }
 
 s32_t ICACHE_FLASH_ATTR SPIFFS_creat(spiffs *fs, const char *path, spiffs_mode mode) {
@@ -542,7 +542,7 @@ static s32_t ICACHE_FLASH_ATTR spiffs_fflush_cache(spiffs *fs, spiffs_file fh) {
           spiffs_get_cache_page(fs, spiffs_get_cache(fs), fd->cache_page->ix),
           fd->cache_page->offset, fd->cache_page->size);
       if (res < SPIFFS_OK) {
-        fs->errno = res;
+        fs->errnum = res;
       }
       spiffs_cache_fd_release(fs, fd->cache_page);
     }
@@ -567,7 +567,7 @@ s32_t ICACHE_FLASH_ATTR SPIFFS_fflush(spiffs *fs, spiffs_file fh) {
 
 void ICACHE_FLASH_ATTR SPIFFS_close(spiffs *fs, spiffs_file fh) {
   if (!SPIFFS_CHECK_MOUNT(fs)) {
-    fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    fs->errnum = SPIFFS_ERR_NOT_MOUNTED;
     return;
   }
   SPIFFS_LOCK(fs);
@@ -582,7 +582,7 @@ void ICACHE_FLASH_ATTR SPIFFS_close(spiffs *fs, spiffs_file fh) {
 
 spiffs_DIR *ICACHE_FLASH_ATTR SPIFFS_opendir(spiffs *fs, const char *name, spiffs_DIR *d) {
   if (!SPIFFS_CHECK_MOUNT(fs)) {
-    fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    fs->errnum = SPIFFS_ERR_NOT_MOUNTED;
     return 0;
   }
   d->fs = fs;
@@ -626,7 +626,7 @@ static s32_t ICACHE_FLASH_ATTR spiffs_read_dir_v(
 
 struct spiffs_dirent *ICACHE_FLASH_ATTR SPIFFS_readdir(spiffs_DIR *d, struct spiffs_dirent *e) {
   if (!SPIFFS_CHECK_MOUNT(d->fs)) {
-    d->fs->errno = SPIFFS_ERR_NOT_MOUNTED;
+    d->fs->errnum = SPIFFS_ERR_NOT_MOUNTED;
     return 0;
   }
   SPIFFS_LOCK(fs);
@@ -651,7 +651,7 @@ struct spiffs_dirent *ICACHE_FLASH_ATTR SPIFFS_readdir(spiffs_DIR *d, struct spi
     d->entry = entry + 1;
     ret = e;
   } else {
-    d->fs->errno = res;
+    d->fs->errnum = res;
   }
   SPIFFS_UNLOCK(fs);
   return ret;
@@ -778,7 +778,7 @@ s32_t ICACHE_FLASH_ATTR SPIFFS_vis(spiffs *fs) {
   } // per block
 
   spiffs_printf("era_cnt_max: %i\n", fs->max_erase_count);
-  spiffs_printf("last_errno:  %i\n", fs->errno);
+  spiffs_printf("last_errno:  %i\n", fs->errnum);
   spiffs_printf("blocks:      %i\n", fs->block_count);
   spiffs_printf("free_blocks: %i\n", fs->free_blocks);
   spiffs_printf("page_alloc:  %i\n", fs->stats_p_allocated);

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -247,19 +247,19 @@
 
 #define SPIFFS_API_CHECK_MOUNT(fs) \
   if (!SPIFFS_CHECK_MOUNT((fs))) { \
-    (fs)->errno = SPIFFS_ERR_NOT_MOUNTED; \
+    (fs)->errnum = SPIFFS_ERR_NOT_MOUNTED; \
     return -1; \
   }
 
 #define SPIFFS_API_CHECK_RES(fs, res) \
   if ((res) < SPIFFS_OK) { \
-    (fs)->errno = (res); \
+    (fs)->errnum = (res); \
     return -1; \
   }
 
 #define SPIFFS_API_CHECK_RES_UNLOCK(fs, res) \
   if ((res) < SPIFFS_OK) { \
-    (fs)->errno = (res); \
+    (fs)->errnum = (res); \
     SPIFFS_UNLOCK(fs); \
     return -1; \
   }

--- a/src/spiffs_nucleus.h
+++ b/src/spiffs_nucleus.h
@@ -395,13 +395,13 @@ typedef struct __attribute(( packed )) {
   // common page header
   spiffs_page_header p_hdr;
   // alignment
-  u8_t _align[4 - (sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3)];
+  u8_t _align[4 - ((sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3))];
   // size of object
   u32_t size;
   // type of object
   spiffs_obj_type type;
   // alignment2
-  u8_t _align2[4 - (sizeof(spiffs_obj_type)&3)==0 ? 4 : (sizeof(spiffs_obj_type)&3)];
+  u8_t _align2[4 - ((sizeof(spiffs_obj_type)&3)==0 ? 4 : (sizeof(spiffs_obj_type)&3))];
   // name of object
   u8_t name[SPIFFS_OBJ_NAME_LEN];
 } spiffs_page_object_ix_header;
@@ -409,7 +409,7 @@ typedef struct __attribute(( packed )) {
 // object index page header
 typedef struct __attribute(( packed )) {
  spiffs_page_header p_hdr;
- u8_t _align[4 - (sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3)];
+ u8_t _align[4 - ((sizeof(spiffs_page_header)&3)==0 ? 4 : (sizeof(spiffs_page_header)&3))];
 } spiffs_page_object_ix;
 
 // callback func for object lookup visitor


### PR DESCRIPTION
The errno problem prevents compilation with newer versions of gcc.
The broken padding results from different execution order of some ambiguous code. Images built with different padding will not be compatible with code that reads the images so this fix must also be applied to Sming at the same time, see PR SmingHub/Sming/pull/307.
